### PR TITLE
Configurable interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ class SimpleExample extends React.Component {
 - `min: number.isRequired` - The minimum limit for the range
 - `max: number.isRequired` - The maximum limit for the range
 - `value: oneOfType([number, arrayOf(number)]).isRequired` - The current value (or values) for the range
+- `interpolation: oneOf(['linear', 'logarithmic'])` - The interpolation method to use. Defaults to `'linear'`. Note that logarithmic interpolation only works for positive values
 - `stepSize: number.isRequired` - The distance between selectable steps
 - `steps: arrayOf(number)` - An array of custom steps to use. This will override `stepSize`,
 - `tickSize: number`

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ class SimpleExample extends React.Component {
 - `min: number.isRequired` - The minimum limit for the range
 - `max: number.isRequired` - The maximum limit for the range
 - `value: oneOfType([number, arrayOf(number)]).isRequired` - The current value (or values) for the range
-- `interpolation: oneOf(['linear', 'logarithmic'])` - The interpolation method to use. Defaults to `'linear'`. Note that logarithmic interpolation only works for positive values
+- `interpolator: shape({ getPercentageForValue: PropType.func, getValueForClientX: PropTypes.func})` - Interpolator to use. See [Interpolation](#Interpolation)
 - `stepSize: number.isRequired` - The distance between selectable steps
 - `steps: arrayOf(number)` - An array of custom steps to use. This will override `stepSize`,
 - `tickSize: number`
@@ -136,6 +136,35 @@ class SimpleExample extends React.Component {
 - `onPress: func` - A function that is called when a handle is pressed.
 - `onDrag: func` - A function that is called when a handled is dragged.
 - `onRelease: func` - A function that is called when a handle is released.
+
+## Interpolation
+
+By default, `react-ranger` uses linear interpolation between data points. We also provide a logarithmic interpolator and an easy way to create your own.
+
+```javascript
+import ReactRanger, { logInterpolator } from "react-ranger";
+...
+<ReactRanger
+  min={0}
+  max={100}
+  stepSize={5}
+  value={value}
+  interpolator={logInterpolator}
+>
+```
+
+One can create their own interpolator by passing an object that implements the interface described below
+
+```
+{
+  // Takes the value & range and returns a percentage [0, 100] where the value sits from left to right
+  getPercentageForValue: (val: number, min: number, max: number): number
+
+  // Takes the clientX (offset from the left edge of the ranger) along with the dimensions
+  // and range settings and transforms a pixel coordinate back into a value
+  getValueForClientX: (clientX: number, trackDims: object, min: number, max: number): number
+}
+```
 
 ## Contributing
 

--- a/src/index.js
+++ b/src/index.js
@@ -170,8 +170,18 @@ class ReactRanger extends React.Component {
     return Math.max(0, Math.min(100, ((val - min) / (max - min)) * 100))
   }
   getValueForClientX = clientX => {
-    const { min, max } = this.props
+    const { min, max, interpolation } = this.props
     const trackDims = getBoundingClientRect(this.trackEl)
+    const { left, width } = trackDims;
+
+    if (interpolation === 'logarithmic') {
+      let value = clientX - left
+      value *= Math.log10(max) - Math.log10(min);
+      value /= width;
+      value = Math.pow(10, Math.log10(min) + value);
+      return value
+    }
+
     const percentageValue = (clientX - trackDims.left) / trackDims.width
     const value = (max - min) * percentageValue
     return value + min

--- a/src/interpolators/index.js
+++ b/src/interpolators/index.js
@@ -1,0 +1,7 @@
+import linearInterpolator from './linear'
+import logInterpolator from './logarithmic'
+
+export {
+    linearInterpolator,
+    logInterpolator,
+}

--- a/src/interpolators/linear.js
+++ b/src/interpolators/linear.js
@@ -1,0 +1,13 @@
+const linearInterpolator = {
+  getPercentageForValue: (val, min, max) => {
+    return Math.max(0, Math.min(100, ((val - min) / (max - min)) * 100))
+  },
+  getValueForClientX: (clientX, trackDims, min, max) => {
+    const { left, width } = trackDims;
+    const percentageValue = (clientX - left) / width
+    const value = (max - min) * percentageValue
+    return value + min
+  },
+}
+
+export default linearInterpolator

--- a/src/interpolators/logarithmic.js
+++ b/src/interpolators/logarithmic.js
@@ -1,0 +1,31 @@
+const logInterpolator = {
+  getPercentageForValue: (val, min, max) => {
+    const minSign = Math.sign(min)
+    const maxSign = Math.sign(max)
+
+    if (minSign !== maxSign) {
+      throw new Error(
+        'Error: logarithmic interpolation does not support ranges that cross 0.'
+      )
+    }
+
+    let percent = 100 / (Math.log10(Math.abs(max)) - Math.log10(Math.abs(min))) * (Math.log10(Math.abs(val)) - Math.log10(Math.abs(min)));
+
+    if (minSign < 0) {
+      // negative range, means we need to invert our percent because of the Math.abs above
+      return 100 - percent;
+    }
+    
+    return percent;
+  },
+  getValueForClientX: (clientX, trackDims, min, max) => {
+    const { left, width } = trackDims;
+    let value = clientX - left
+    value *= Math.log10(max) - Math.log10(min);
+    value /= width;
+    value = Math.pow(10, Math.log10(min) + value);
+    return value
+  },
+}
+
+export default logInterpolator


### PR DESCRIPTION
Allows configuration between `'linear'` and `'logarithmic'` interpolation. Log interpolation only works for positive values at the moment.

@tannerlinsley lemme know your thoughts on how to split out the logic. I was thinking about using a file for each type of scale to contain the logic.